### PR TITLE
Commit after each query to avoid holding transactions open.

### DIFF
--- a/multiquery.py
+++ b/multiquery.py
@@ -80,6 +80,11 @@ def run(conn, query, dbnames):
 
                 for row in cursor:
                     print("\t".join(encode(v) for v in row))
+
+                # Make sure any open transactions are closed now, rather
+                # than after multiquery finishes all the DBs
+                conn.commit()
+                
             except KeyboardInterrupt as e:
                 sys.stderr.write("^C received.  Shutting down.\n")
                 raise


### PR DESCRIPTION
By default, PyMySQL connections have [autocommit](https://mariadb.com/kb/en/mariadb/mysql_autocommit/) turned off, which means that changes will not be committed until you call `connection.commit()`. In turn, this means that if your database server decides to open a transaction or create locks to handle an individual query with the multiquery, those transactions and locks will remain open until the whole multiquery finishes. With this patch, all the transactions and locks are closed after each individual query finishes.
